### PR TITLE
Don't suppress important debug logs

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Spawning/SpawnGroupManager.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/SpawnGroupManager.cs
@@ -310,15 +310,7 @@ namespace ModularEncountersSystems.Spawning {
 
 				}
 
-				if (spawnGroup.SpawnConditionsProfiles.Count == conditionsFailedBySpawnType) {
-
-					SpawnLogger.QueuedItems.Clear();
-
-				} else {
-
-					SpawnLogger.ProcessQueue();
-				
-				}
+				SpawnLogger.ProcessQueue();
 
 			}
 


### PR DESCRIPTION
Took me hours to figure out one simple thing because logs are deliberately "cleared" in certain conditions. 

Custom spawns (via scripting API) requires that the spawn group profile has a `[RivalAiSpawn:true]` tag ([which is NOT written on the Wiki too](https://github.com/MeridiusIX/Modular-Encounters-Systems/wiki/Scripting-API)) and I couldn't figure that out until I dug up these "cleared" logs and searched through conversations on Discord. 

It's a waste of opportunity that the logs do deliver the necessary hint yet they're "cleared" in the last mile. At least the `[RivalAiSpawn:true]` requirement should be written on Wiki.