### PR TITLE
Add {AntennaName} and {GridName} tags to GPS Labels

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/BroadcastSystem.cs
+++ b/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/BroadcastSystem.cs
@@ -244,9 +244,17 @@ namespace ModularEncountersSystems.Behavior.Subsystems {
 				}
 
 				if (modifiedMsg.Contains("{GPS}") == true) {
+					
+					var modifiedLabel = chat.GPSLabel;
+					
+					if (modifiedLabel.Contains("{AntennaName}") && ) 
+						modifiedLabel = modifiedLabel.Replace("{AntennaName}", this.HighestAntennaRangeName);
+					
+					if(this.RemoteControl?.SlimBlock?.CubeGrid?.CustomName != null && modifiedLabel.Contains("{GridName}"))
+						modifiedLabel = modifiedLabel.Replace("{GridName}", this.RemoteControl.SlimBlock.CubeGrid.CustomName);
 
-					modifiedMsg = modifiedMsg.Replace("{GPS}", GetGPSString(chat.GPSLabel));
-					SendGPSToPlayer(chat.GPSLabel, RemoteControl.SlimBlock.CubeGrid.WorldAABB.Center, player.IdentityId);
+					modifiedMsg = modifiedMsg.Replace("{GPS}", GetGPSString(modifiedLabel));
+					SendGPSToPlayer(modifiedLabel, RemoteControl.SlimBlock.CubeGrid.WorldAABB.Center, player.IdentityId);
 
 				}
 


### PR DESCRIPTION
When broadcasting a spawns GPS location via a Chat action, GPSLabel is a fixed arbitrary string.  Multiple spawns yield multiple GPS entries with identical labels.  ChatMessages and Author support {AntennaName} and {GridName} tags, this change extends tag support to GPSLabel also.