### PR TITLE
Fix for ReputationMaxCap

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Helpers/FactionHelper.cs
+++ b/Data/Scripts/ModularEncountersSystems/Helpers/FactionHelper.cs
@@ -295,7 +295,7 @@ namespace ModularEncountersSystems.Helpers {
 						newRep = MathHelper.Clamp(oldRep + amount, minRep, maxRep);
 					else {
 					
-						if((proposedRep < minRep && Math.Sign(amount) == 1) || (proposedRep > minRep && Math.Sign(amount) == -1))
+						if((proposedRep < maxRep && Math.Sign(amount) == 1) || (proposedRep > minRep && Math.Sign(amount) == -1))
 							newRep = oldRep + amount;
 
 					}


### PR DESCRIPTION
This should allow ReputationMaxCap to correctly limit rep gains.  It was previously checking against minRep for both positive and negative changes.