### PR TITLE
entity evaluator: fix threat score inventory modifier

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Entities/EntityEvaluator.cs
+++ b/Data/Scripts/ModularEncountersSystems/Entities/EntityEvaluator.cs
@@ -790,7 +790,7 @@ namespace ModularEncountersSystems.Entities {
 
 						var inventoryModifier = ((float)block.Block.GetInventory().CurrentVolume / (float)block.Block.GetInventory().MaxVolume) + 1;
 
-						if (result == float.NaN)
+						if (inventoryModifier != float.NaN)
 							value *= inventoryModifier;
 
 					}


### PR DESCRIPTION
The current check doesn't make sense to me:
- if result is NaN, then result will still be NaN after the addition (line 800)
- when result is not NaN, it means we actually never use the inventory modifier
- I suspect the intention was to check for division by zero in case MaxVolume was zero, and only if not then multiply with the inventoryModifier

Thanks for the cool mod/system!