### PR TITLE
Bug fix for close planets and moons

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Entities/PlanetManager.cs
+++ b/Data/Scripts/ModularEncountersSystems/Entities/PlanetManager.cs
@@ -31,11 +31,10 @@ namespace ModularEncountersSystems.Entities {
             return 0;
         
         }
-
+		
         public static PlanetEntity GetNearestPlanet(Vector3D coords) {
 
             PlanetEntity planet = null;
-            bool inGravity = false;
             double distance = -1;
 
             foreach (var planetEnt in Planets) {
@@ -44,29 +43,15 @@ namespace ModularEncountersSystems.Entities {
                     continue;
 
                 if (planetEnt.IsPositionInGravity(coords)) {
+					var thisDist = Math.Abs(Vector3D.Distance(planetEnt.Center(), coords)-planetEnt.Planet.AverageRadius);
 
-                    planet = planetEnt;
-                    inGravity = true;
-
-                } else if (inGravity) {
-
-                    continue;
-                
-                }
-
-                var thisDist = Vector3D.Distance(planetEnt.Center(), coords);
-
-                if (distance == -1 || thisDist < distance) {
-
-                    planet = planetEnt;
-                    distance = thisDist;
-
-                }
-            
+					if (distance == -1 || thisDist < distance) {
+						planet = planetEnt;
+						distance = thisDist;
+					}
+                }             
             }
-
             return planet;
-
         }
 
         public static PlanetEntity GetPlanetWithName(string generatorName) {


### PR DESCRIPTION
There was an issue with the comparison to find which planet to spawn in reference to where a small and large body close together caused issues. Changed it to use the distance to the *surface* to compare, instead of the core.