### PR TITLE
Add DefaultGridName pattern to name manipulations

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/PrefabManipulation.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/PrefabManipulation.cs
@@ -674,7 +674,7 @@ namespace ModularEncountersSystems.Spawning.Manipulation {
 
 				if (prefab.Prefab.CubeGrids.Length > 0) {
 
-					prefab.Prefab.CubeGrids[0].DisplayName = newRandomName;
+					prefab.Prefab.CubeGrids[0].DisplayName = RandomNameGenerator.ProcessGridname(newRandomName, prefab.Prefab.CubeGrids[0].DisplayName);
 					MyCubeBlockDefinition antennaDef = null;
 
 					foreach (var grid in prefab.Prefab.CubeGrids) {

--- a/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/RandomNameGenerator.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/RandomNameGenerator.cs
@@ -493,8 +493,19 @@ namespace ModularEncountersSystems.Spawning.Manipulation {
 
 		};
 
+		public static string ProcessGridname(string pattern, string gridName){
+			string newPattern = pattern;
+			string keyword = "DefaultGridName";
+			
+			// Prevent recursion
+			if (gridName.Contains(keyword)){
+				return newPattern;
+			}
 
+			newPattern = ProcessString(newPattern, keyword, (new string [] {gridName}) );
 
+			return newPattern;
+		}
 		public static string CreateRandomNameFromPattern(string pattern) {
 
 			string newPattern = pattern;


### PR DESCRIPTION
Link to discussion on Discord:
https://discord.com/channels/398249868805537803/557949898922786816/1117143451444727948

In short, this change allows modders to create a RandomGridNamePattern which takes into account the display name of grids from the prefabs. This allows multiple spawngroups to use the same manipulation profile, and still result in the spawned grids having a name unique to their original grid display name.

To illustrate this, below is an image of some different grids spawned, each using the same pattern: `FishNoun DefaultGridName RandomNumberRandomNumberRandomNumberRandomLetter`

![20240122192831_1](https://github.com/MeridiusIX/Modular-Encounters-Systems/assets/40660991/1e0bdcd0-6afc-4f3f-81e1-5a6c02f5b49d)

After this update, using the exact same configurations, the result looks like this:

![20240122200454_1](https://github.com/MeridiusIX/Modular-Encounters-Systems/assets/40660991/620bd47f-a889-4270-aec2-2f70e636f31b)