### PR TITLE
Fixed bad NaN comparison with floating point numbers

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/AutoPilot/RotationSystem.cs
+++ b/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/AutoPilot/RotationSystem.cs
@@ -271,7 +271,7 @@ namespace ModularEncountersSystems.Behavior.Subsystems.AutoPilot {
 
 		public float LimitSpeed(float proposedSpeed, double actualSpeed) {
 
-			if (proposedSpeed == float.NaN || actualSpeed == double.NaN)
+			if (float.IsNaN(proposedSpeed) || double.IsNaN(actualSpeed))
 				return 0;
 
 			if (proposedSpeed == 0 || Math.Sign(proposedSpeed) != Math.Sign(actualSpeed))


### PR DESCRIPTION
This resolves an Arithemetic exception that is being caused in the RotationSystem portion of the AutoPilotSystem class. Tested via unit test injection of specific code path and resolves properly to 0. 