### PR TITLE
Add static grid check for NPCShieldProvider

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/NPCShieldManager.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/NPCShieldManager.cs
@@ -58,7 +58,7 @@ namespace ModularEncountersSystems.Spawning.Manipulation {
 				return false;
 
 			SpawnLogger.Write("DSP: Check if Spawn Eligible", SpawnerDebugEnum.Manipulation);
-			if (!IsGlobalShieldProviderEnabled() || !spawnGroupAdd)
+			if (cubeGrid.IsStatic || !cubeGrid.IsStatic || !IsGlobalShieldProviderEnabled() || !spawnGroupAdd)
 				return false;
 
 			MyObjectBuilder_CubeBlock minArmor = null;

--- a/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/NPCShieldManager.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/NPCShieldManager.cs
@@ -58,7 +58,7 @@ namespace ModularEncountersSystems.Spawning.Manipulation {
 				return false;
 
 			SpawnLogger.Write("DSP: Check if Spawn Eligible", SpawnerDebugEnum.Manipulation);
-			if (cubeGrid.IsStatic || !cubeGrid.IsStatic || !IsGlobalShieldProviderEnabled() || !spawnGroupAdd)
+			if (cubeGrid.IsStatic || !IsGlobalShieldProviderEnabled() || !spawnGroupAdd)
 				return false;
 
 			MyObjectBuilder_CubeBlock minArmor = null;

--- a/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/PrefabManipulation.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/PrefabManipulation.cs
@@ -538,7 +538,7 @@ namespace ModularEncountersSystems.Spawning.Manipulation {
 
 				foreach (var grid in prefab.Prefab.CubeGrids) {
 
-					if (!grid.IsStatic && !data.Attributes.ShieldActivation && NPCShieldManager.AddDefenseShieldsToGrid(grid, true)) {
+					if (!data.Attributes.ShieldActivation && NPCShieldManager.AddDefenseShieldsToGrid(grid, true)) {
 
 						data.Attributes.ShieldActivation = true;
 						break;

--- a/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/PrefabManipulation.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/Manipulation/PrefabManipulation.cs
@@ -538,7 +538,7 @@ namespace ModularEncountersSystems.Spawning.Manipulation {
 
 				foreach (var grid in prefab.Prefab.CubeGrids) {
 
-					if (!data.Attributes.ShieldActivation && NPCShieldManager.AddDefenseShieldsToGrid(grid, true)) {
+					if (!grid.IsStatic && !data.Attributes.ShieldActivation && NPCShieldManager.AddDefenseShieldsToGrid(grid, true)) {
 
 						data.Attributes.ShieldActivation = true;
 						break;


### PR DESCRIPTION
Will provide a simple fix for issue https://github.com/MeridiusIX/Modular-Encounters-Systems/issues/301

This simple PR adds a simple check to the checks before starting NPCShieldProvider block manipulation on a prefab - the added check is if it is a static grid or not.

As NPCShieldProvider provided shields do not work on static grids, this check will ensure a game using NPCShieldProviders is as functional as possible, by preventing Static grids from recieving broken shields while allowing normal non-static grids to recieve working shields normally.

Tested with vanilla prefabs and a range of MES mods.  Appears to be working correctly.

The fact that static grids do not have working NPCShieldProvider shields may need to be addressed in a more in-depth future PR.