### PR TITLE
CustomSpawnRequest2 with arbitrary user data inserted into NpcData

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/API/LocalAPI.cs
+++ b/Data/Scripts/ModularEncountersSystems/API/LocalAPI.cs
@@ -52,6 +52,7 @@ namespace ModularEncountersSystems.API {
 			dict.Add("BehaviorTriggerActivationWatcher", new Action<bool, Action<IMyRemoteControl, string, string, IMyEntity, Vector3D>>(ChangeBehaviorTriggerWatcher));
 			dict.Add("ChatCommand", new Action<string, MatrixD, long, ulong>(ChatManager.ChatFromApi));
 			dict.Add("CustomSpawnRequest", new Func<List<string>, MatrixD, Vector3, bool, string, string, bool>(CustomSpawnRequest));
+			dict.Add("CustomSpawnRequest2", new Func<Dictionary<string, object>, bool>(CustomSpawnRequest2));
 			dict.Add("GetDespawnCoords", new Func<IMyCubeGrid, Vector3D>(GetDespawnCoords));
 			dict.Add("GetPlayerInhibitorData", new Action<long, string, List<MyTuple<IMyRadioAntenna, DateTime>>>(GetPlayerInhibitorData));
 			dict.Add("GetSpawnGroupBlackList", new Func<List<string>>(GetSpawnGroupBlackList));
@@ -175,6 +176,12 @@ namespace ModularEncountersSystems.API {
 
 			return SpawnRequest.CalculateSpawn(spawningMatrix.Translation, "API Request: " + spawnProfileId, SpawningType.OtherNPC, ignoreSafetyCheck, true, spawnGroups, factionOverride, spawningMatrix, velocity);
 
+		}
+
+		public static bool CustomSpawnRequest2(Dictionary<string, object> dict)
+		{
+			var args = MESApi.CustomSpawnRequestArgs.FromDictionary(dict);
+			return SpawnRequest.CalculateSpawn(args.SpawningMatrix.Translation, "API Request: " + args.SpawnProfileId, SpawningType.OtherNPC, args.IgnoreSafetyCheck, true, args.SpawnGroups, args.FactionOverride, args.SpawningMatrix, args.Velocity, context: args.Context);
 		}
 
 		//ApiSpawnRequest

--- a/Data/Scripts/ModularEncountersSystems/Spawning/PrefabSpawner.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/PrefabSpawner.cs
@@ -47,7 +47,7 @@ namespace ModularEncountersSystems.Spawning {
 		
 		}
 
-		public static bool ProcessSpawning(SpawnGroupCollection spawnCollection, PathDetails path, EnvironmentEvaluation environment) {
+		public static bool ProcessSpawning(SpawnGroupCollection spawnCollection, PathDetails path, EnvironmentEvaluation environment, string context) {
 
 			if (!path.SpawnType.HasFlag(SpawningType.Creature)) {
 
@@ -55,7 +55,7 @@ namespace ModularEncountersSystems.Spawning {
 				SpawnVoxels(spawnCollection, path);
 
 				//Then Do Prefabs
-				SpawnPrefab(spawnCollection, path, environment);
+				SpawnPrefab(spawnCollection, path, environment, context);
 
 			} else {
 			
@@ -123,7 +123,7 @@ namespace ModularEncountersSystems.Spawning {
 
 		}
 
-		public static void SpawnPrefab(SpawnGroupCollection spawnCollection, PathDetails path, EnvironmentEvaluation environment) {
+		public static void SpawnPrefab(SpawnGroupCollection spawnCollection, PathDetails path, EnvironmentEvaluation environment, string context) {
 
 			string spawnGroupTimeStamp = DateTime.Now.ToString();
 			string faction = spawnCollection.SelectRandomFaction();
@@ -201,6 +201,7 @@ namespace ModularEncountersSystems.Spawning {
 				npcData.EndCoords = path.GetPrefabEndCoords(sgPrefab.Position, environment, spawnCollection.Conditions.CustomPathEndAltitude);
 				npcData.Forward = path.SpawnMatrix.Forward;
 				npcData.Up = path.SpawnMatrix.Up;
+				npcData.Context = context;
 
 				Vector3 linearVelocity = Vector3.Zero;
 				Vector3 angularVelocity = Vector3.Zero;

--- a/Data/Scripts/ModularEncountersSystems/Spawning/SpawnRequest.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/SpawnRequest.cs
@@ -262,7 +262,7 @@ namespace ModularEncountersSystems.Spawning {
 		
 		}
 
-		public static bool CalculateSpawn(Vector3D coords, string source, SpawningType type = SpawningType.None, bool forceSpawn = false, bool adminSpawn = false, List<string> eligibleNames = null, string factionOverride = null, MatrixD spawnMatrix = new MatrixD(), Vector3D customVelocity = new Vector3D(), bool ignoreSafetyChecks = false, long ownerOverride = -1, long eventInstance = -1) {
+		public static bool CalculateSpawn(Vector3D coords, string source, SpawningType type = SpawningType.None, bool forceSpawn = false, bool adminSpawn = false, List<string> eligibleNames = null, string factionOverride = null, MatrixD spawnMatrix = new MatrixD(), Vector3D customVelocity = new Vector3D(), bool ignoreSafetyChecks = false, long ownerOverride = -1, long eventInstance = -1, string context = null) {
 
 			SpawnLogger.Write("Spawn Request Received From: " + source, SpawnerDebugEnum.Spawning);
 
@@ -415,7 +415,7 @@ namespace ModularEncountersSystems.Spawning {
 				SpawnLogger.Write("Initializing Boss Encounter", SpawnerDebugEnum.Spawning);
 				SpawnLogger.Write(string.Format("[{0}] Initializing Boss Encounter Event / Signal", string.IsNullOrWhiteSpace(source) ? "null" : source), SpawnerDebugEnum.SpawnRecord);
 				var bossEncounter = new StaticEncounter();
-				bossEncounter.InitBossEncounter(spawnGroupCollection.SpawnGroup.SpawnGroupName, spawnGroupCollection.ConditionsIndex, path.StartCoords, spawnGroupCollection.SelectRandomFaction(), spawnTypes);
+				bossEncounter.InitBossEncounter(spawnGroupCollection.SpawnGroup.SpawnGroupName, spawnGroupCollection.ConditionsIndex, path.StartCoords, spawnGroupCollection.SelectRandomFaction(), spawnTypes, context);
 				NpcManager.StaticEncounters.Add(bossEncounter);
 				NpcManager.UpdateStaticEncounters();
 				return true;
@@ -436,7 +436,7 @@ namespace ModularEncountersSystems.Spawning {
 			} else {
 
 				SpawnLogger.Write("SpawnGroup Sent To Prefab Spawner", SpawnerDebugEnum.Spawning);
-				result = PrefabSpawner.ProcessSpawning(spawnGroupCollection, path, environment);
+				result = PrefabSpawner.ProcessSpawning(spawnGroupCollection, path, environment, context);
 
 			}
 
@@ -536,7 +536,7 @@ namespace ModularEncountersSystems.Spawning {
 
 			SpawnLogger.Write("Attempting Spawn", SpawnerDebugEnum.Spawning);
 
-			var result = PrefabSpawner.ProcessSpawning(spawnGroupCollection, path, environment);
+			var result = PrefabSpawner.ProcessSpawning(spawnGroupCollection, path, environment, encounter.Context);
 
 			if (!result)
 				return false;

--- a/Data/Scripts/ModularEncountersSystems/Spawning/StaticEncounter.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/StaticEncounter.cs
@@ -107,6 +107,9 @@ namespace ModularEncountersSystems.Spawning {
 		[ProtoMember(29)]
 		public List<string> PreviouslySpawnedPrefabs;
 
+		[ProtoMember(30)]
+		public string Context;
+
 		//Non-Serialized
 
 		[ProtoIgnore]
@@ -189,9 +192,10 @@ namespace ModularEncountersSystems.Spawning {
 
 			PreviouslySpawnedPrefabs = new List<string>();
 
+			Context = "";
 		}
 
-		public void InitBossEncounter(string spawnGroupName, int condition, Vector3D coords, string faction, SpawningType type) {
+		public void InitBossEncounter(string spawnGroupName, int condition, Vector3D coords, string faction, SpawningType type, string context) {
 
 			IsValid = true;
 			IsBoss = true;
@@ -199,6 +203,7 @@ namespace ModularEncountersSystems.Spawning {
 			ConditionIndex = condition;
 			TriggerCoords = coords;
 			Faction = faction;
+			Context = context;
 
 			TriggerRadius = Settings.BossEncounters.TriggerDistance;
 			UseSpecificPlayers = true;

--- a/Data/Scripts/ModularEncountersSystems/World/NpcData.cs
+++ b/Data/Scripts/ModularEncountersSystems/World/NpcData.cs
@@ -405,6 +405,9 @@ namespace ModularEncountersSystems.World {
 		[ProtoMember(41)]
 		public string TerrainTypeName; //Store data for MatchTerrainType in AI conditions 
 
+		[ProtoMember(42)]
+		public string Context; // arbitrary user data via MESApi
+
 		//Non-Serialized Data
 
 		[ProtoIgnore]


### PR DESCRIPTION
### Changes
Added a new parameter `string context` to `MESApi.CustomSpawnRequest()`, which is inserted into `NpcData.Context` of spawned NPC grids.

### Background
I wasn't able to reliably track each spawn request's corresponding grid when I spawn a single spawn group multiple times simultaneously in close proximity. I guess that kind of usage wasn't expected. This PR would allow me to retrieve an identifier of each spawn request upon a callback of `RegisterSuccessfulSpawnAction()` or a modded block's init function. 

For an added value, the string data can carry around XML which may be useful to pass arbitrary data to grids.

### Implementation notes
For backward compatibility, I didn't get to change the signature of `CustomSpawnRequest()` but added an override, with a single parameter `args`, which is of new type `CustomSpawnRequestArgs`. Internally, API will pass around a `string -> object` dictionary that is converted to/from this class.

This approach also allows you to safely add other parameters to the function in future updates.

### Tests conducted prior to PR
- ran new `CustomSpawnRequest()` with `context` data and confirmed working as expected.
- ran the original `CustomSpawnRequest()` and confirmed that the behavior hasn't changed.
- ran general MES spawner via `/MES.SSCS` and natural spawns and confirmed the behavior hasn't changed.
