### PR TITLE
Fix to CheckTargetAltitudeDifference missing an absolute value.

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/Trigger/ConditionProfile.cs
+++ b/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/Trigger/ConditionProfile.cs
@@ -695,7 +695,7 @@ namespace ModularEncountersSystems.Behavior.Subsystems.Trigger {
 					var planetPos = _behavior.AutoPilot.CurrentPlanet.Center();
 					var targetCoreDist = _behavior.AutoPilot.Targeting.Target.Distance(planetPos);
 					var myCoreDist = Vector3D.Distance(planetPos, _remoteControl.GetPosition());
-					var difference = targetCoreDist - myCoreDist;
+					var difference = Math.Abs(targetCoreDist - myCoreDist);
 
 					if (difference >= ConditionReference.MinTargetAltitudeDifference && difference <= ConditionReference.MaxTargetAltitudeDifference)
 						satisfiedConditions++;


### PR DESCRIPTION
Currently CheckTargetAltitudeDifference only works if the target's altitude is greater than the NPC's altitude, because the code is missing an absolute value in the difference between the target's altitude and NPC's altitude.

When the target is above the NPC then difference is negative.  When that is compared to MinTargetAltitudeDifference and MaxTargetAltitudeDifference (which are always positive), it fails. 

Taking the absolute value of the difference fixes this issue.