### PR TITLE
Allow `MESAPI` and `[RivalAI Spawn]` to spawn grids without RivalAI flags

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/API/MESApi.cs
+++ b/Data/Scripts/ModularEncountersSystems/API/MESApi.cs
@@ -113,7 +113,7 @@ namespace ModularEncountersSystems.API {
 		public void ChatCommand(string message, MatrixD playerPosition, long identityId, ulong steamUserId) => _chatCommand?.Invoke(message, playerPosition, identityId, steamUserId);
 
 		/// <summary>
-		/// Used To Spawn A Random SpawnGroup From A Provided List At A Provided Location. The Spawn Will Not Be Categorized As A CargoShip/RandomEncounter/Etc. The spawngroup/conditions must also use the [RivalAiSpawn:true] tag to be able to spawn with this command.
+		/// Used To Spawn A Random SpawnGroup From A Provided List At A Provided Location. The Spawn Will Not Be Categorized As A CargoShip/RandomEncounter/Etc.
 		/// </summary>
 		/// <param name="spawnGroups">List of SpawnGroups you want to attempt spawning from</param>
 		/// <param name="coords">The coordinates the Spawn will use</param>
@@ -125,7 +125,7 @@ namespace ModularEncountersSystems.API {
 		public bool CustomSpawnRequest(List<string> spawnGroups, MatrixD spawningMatrix, Vector3 velocity, bool ignoreSafetyCheck, string factionOverride, string spawnProfileId) => _customSpawnRequest?.Invoke(spawnGroups, spawningMatrix, velocity, ignoreSafetyCheck, factionOverride, spawnProfileId) ?? false;
 
 		/// <summary>
-		/// Used To Spawn A Random SpawnGroup From A Provided List At A Provided Location. The Spawn Will Not Be Categorized As A CargoShip/RandomEncounter/Etc. The spawngroup/conditions must also use the [RivalAiSpawn:true] tag to be able to spawn with this command.
+		/// Used To Spawn A Random SpawnGroup From A Provided List At A Provided Location. The Spawn Will Not Be Categorized As A CargoShip/RandomEncounter/Etc.
 		/// </summary>
 		public bool CustomSpawnRequest(CustomSpawnRequestArgs args) => _customSpawnRequest2?.Invoke(args.ToDictionary()) ?? false;
 		

--- a/Data/Scripts/ModularEncountersSystems/Spawning/SpawnConditions.cs
+++ b/Data/Scripts/ModularEncountersSystems/Spawning/SpawnConditions.cs
@@ -171,7 +171,7 @@ namespace ModularEncountersSystems.Spawning {
 			if (type.HasFlag(SpawningType.Creature) && conditions.CreatureSpawn)
 				return true;
 
-			if (type.HasFlag(SpawningType.OtherNPC) && (conditions.RivalAiAnySpawn || conditions.RivalAiAtmosphericSpawn || conditions.RivalAiSpaceSpawn || conditions.RivalAiSpawn))
+			if (type.HasFlag(SpawningType.OtherNPC))
 				return true;
 
 			if (type.HasFlag(SpawningType.StaticEncounterSpace) || type.HasFlag(SpawningType.StaticEncounterPlanet) && conditions.StaticEncounter)


### PR DESCRIPTION
## Proposal

Edit this conditional check in spawn request:
```diff
- if (type.HasFlag(SpawningType.OtherNPC) && (conditions.RivalAiAnySpawn || conditions.RivalAiAtmosphericSpawn || conditions.RivalAiSpaceSpawn || conditions.RivalAiSpawn))
+ if (type.HasFlag(SpawningType.OtherNPC))
```

This PR will allow modders to spawn grids via `MESAPI` and `[RivalAI Spawn]` without redundant flags in spawn condition profile.

## Discussions

Previously, the code above was preventing `MESAPI` and `[RivalAI Spawn]` from spawning grids who didn't have one of these flags: 

- `RivalAiAnySpawn`
- `RivalAiAtmosphericSpawn`
- `RivalAiSpaceSpawn`
- `RivalAiSpawn`

These flags are used nowhere else.

### Why these flags needed to be added to spawn condition profiles

No idea.

### Spawn condition profile (example)

```diff
  [MES Spawn Conditions]
  [SpaceCargoShip:false]
- [RivalAiSpaceSpawn:true]
  [UseThreatLevelCheck:false]
  [FactionOwner:BERTI]
```

## Other note

Tested in local environment.