### PR TITLE
Fixes trigger custom counters getting “stuck” after save/reload.

### DIFF
--- a/Data/Scripts/ModularEncountersSystems/Behavior/CoreBehavior.cs
+++ b/Data/Scripts/ModularEncountersSystems/Behavior/CoreBehavior.cs
@@ -1325,6 +1325,7 @@ namespace ModularEncountersSystems.Behavior {
 
 			}
 
+			Trigger.UpdateBehaviorSettings(BehaviorSettings);
 			BehaviorSettings.Behavior = this;
 
 

--- a/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/Trigger/TriggerSystem.cs
+++ b/Data/Scripts/ModularEncountersSystems/Behavior/Subsystems/Trigger/TriggerSystem.cs
@@ -1496,6 +1496,15 @@ namespace ModularEncountersSystems.Behavior.Subsystems.Trigger {
 
 		}
 
+		public void UpdateBehaviorSettings(StoredSettings settings) {
+
+			if (settings == null)
+				return;
+
+			_settings = settings;
+
+		}
+
 		public void RegisterCommandListener() {
 
 			if (CommandListenerRegistered)


### PR DESCRIPTION
Bug:
TriggerSystem is assigned BehaviorSettings early, then CoreBehavior replaces BehaviorSettings from storage, replacing the local reference but without updating TriggerSystem. After server reload, actions wrote counter updates to the stale settings object, so visible loaded values never advanced.

Fix:
Added setter TriggerSystem.UpdateBehaviorSettings(StoredSettings) and call it after settings load/fallback in CoreBehavior.PostTagsSetup(), so trigger/action counter writes always target the active BehaviorSettings instance. You could call SetupReferences(...) instead but this avoids re-passing unrelated subsystem refs in PostTagsSetup() and limits future side-effects if SetupReferences() changes later.